### PR TITLE
Get new LM10 form data

### DIFF
--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -219,6 +219,31 @@ class LM10Report:
                 ),
             }
 
+            if table.xpath(".//span[@class='i-label' and text()='12b.']").get():
+                activity["federal_work"] = normalize_space(
+                    table.xpath(
+                        ".//span[@class='i-label' and text()='12b.']"
+                        "/parent::div/parent::div"
+                        "/following-sibling::div"
+                        "//div[@class='i-value']"
+                        "//span[@class='i-xcheckbox']"
+                        "/following-sibling::text()"
+                    ).get()
+                )
+
+                activity["uei"] = normalize_space(
+                    table.xpath(".//div[@class='col-xs-10' and text()[contains(.,'Unique Entity Identifier (UEI):')]]/text()").get()
+                )
+
+                if table.xpath(".//div[@class='col-xs-3' and text()[contains(.,'No UEI')]]//span[@class='i-xcheckbox']").get():
+                    activity["no_uei_checkbox"] = 'Checked'
+                else:
+                    activity["no_uei_checkbox"] = 'Not checked'
+            else:
+                activity["federal_work"] = 'Field not present'
+                activity["uei"] = 'Field not present'
+                activity["no_uei_checkbox"] = 'Field not present'
+
             expenditure_table = table.xpath(
                 ".//table[@class='addTable' and descendant::span[@class='i-label' and normalize-space(text())='11.a. Date of each payment or expenditure (mm/dd/yyyy).']]"
             )

--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -239,10 +239,34 @@ class LM10Report:
                     activity["no_uei_checkbox"] = 'Checked'
                 else:
                     activity["no_uei_checkbox"] = 'Not checked'
+                
+                # When federal_work is "Yes" a new table may appear with different categories of agencies
+                if table.xpath(".//span[@class='i-label' and text()='12b.']/following::tbody").get():
+                    agencies = ""
+                    unlisted_agencies = ""
+                    for row in table.xpath(".//span[@class='i-label' and text()='12b.']/following::tbody/child::tr"):
+                        if row.xpath(".//td[1]/text()"): agencies += row.xpath(".//td[1]/text()").get() + ", "
+                        if row.xpath(".//td[2]/text()"): unlisted_agencies += row.xpath(".//td[2]/text()").get() + ", "
+
+                    if agencies == "":
+                        activity["agencies"] = "None"
+                    else:
+                        activity["agencies"] = agencies.strip(", ")
+
+                    if unlisted_agencies == "":
+                        activity["unlisted_agencies"] = "None"
+                    else:
+                        activity["unlisted_agencies"] = unlisted_agencies.strip(", ")
+                else:
+                    activity["agencies"] = "Field not present"
+                    activity["unlisted_agencies"] = "Field not present"
+
             else:
                 activity["federal_work"] = 'Field not present'
                 activity["uei"] = 'Field not present'
                 activity["no_uei_checkbox"] = 'Field not present'
+                activity["agencies"] = 'Field not present'
+                activity["unlisted_agencies"] = 'Field not present'
 
             expenditure_table = table.xpath(
                 ".//table[@class='addTable' and descendant::span[@class='i-label' and normalize-space(text())='11.a. Date of each payment or expenditure (mm/dd/yyyy).']]"


### PR DESCRIPTION
## Overview
This grabs the new 12b fields and the table that occasionally appears after it.

### Testing
- Run `make lm10.b` and check the activity table
- Confirm that old forms have the new columns, but say "Field not present"
- Confirm that [new forms like this one](https://olmsapps.dol.gov/query/orgReport.do?rptId=874979&rptForm=LM10Form) have new columns filled with the appropriate values