### PR TITLE
Retry a few times if the file number of html report is suspicious

### DIFF
--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -105,7 +105,7 @@ class LM20(Spider):
 
         yield item
 
-    def parse_html_report(self, response, item, report):
+    def parse_html_report(self, response, item, report, attempts=0):
 
         # baffling, sometimes when you request some resources
         # it returns html and sometime it returns a pdf
@@ -113,18 +113,23 @@ class LM20(Spider):
             response.headers.get("Content-Type").decode()
         )
 
+        keep_trying = True
+
         if content_type == "text/html" and b"Signature" in response.body:
 
             form_data = report.parse(response)
 
-            item["detailed_form_data"] = form_data
+            if str(item["srNum"]) == form_data["file_number"] or attempts > 2:
+                item["detailed_form_data"] = form_data
+                yield item
+                keep_trying = False
+            else:
+                attempts += 1
 
-            yield item
-
-        else:
+        if keep_trying:
             yield Request(
                 response.request.url,
-                cb_kwargs={"item": item, "report": report},
+                cb_kwargs={"item": item, "report": report, "attempts": attempts},
                 callback=self.parse_html_report,
                 dont_filter=True,
             )


### PR DESCRIPTION
Implements the same logic as in this similar lm20 pr: https://github.com/labordata/lm20/pull/15

- Closes #7

### Testing
- I first tested by using a breakpoint if ever it retried, which it did. Then adjusted to use the breakpoint if the attempts ever exceeded 2, which it did not on a full run.