### PR TITLE
Patch infinite loop in report parsing

### DIFF
--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -118,12 +118,21 @@ class LM20(Spider):
 
         if content_type == "text/html" and b"Signature" in response.body:
             form_data = report.parse(response)
-            if str(item["srNum"]) == form_data["file_number"] or attempts >= max_attempts:
+
+            if str(item["srNum"]) == form_data["file_number"]:
                 item["detailed_form_data"] = form_data
-                yield item
-                return  # done
+
+            elif attempts >= max_attempts:
+                print(
+                    f"could not parse report for srNum {item["srNum"]} at "
+                    f"{response.request.url}"
+                )
+
+            yield item
+            return  # done
 
         attempts += 1
+
         if attempts <= max_attempts:
             yield Request(
                 response.request.url,
@@ -131,8 +140,6 @@ class LM20(Spider):
                 callback=self.parse_html_report,
                 dont_filter=True,
             )
-        else:
-            print(f"Droppped item: {item}")
 
 
 class LM10Report:

--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -106,7 +106,6 @@ class LM20(Spider):
         yield item
 
     def parse_html_report(self, response, item, report, attempts=0):
-
         # baffling, sometimes when you request some resources
         # it returns html and sometime it returns a pdf
 
@@ -115,28 +114,25 @@ class LM20(Spider):
 
         content_type, _ = m.get_params()[0]
 
-        keep_trying = True
+        max_attempts = self.settings.getint("MISMATCHED_FILER_RETRY", 10)
 
         if content_type == "text/html" and b"Signature" in response.body:
-
             form_data = report.parse(response)
-
-            if str(item["srNum"]) == form_data[
-                "file_number"
-            ] or attempts > self.settings.getint("MISMATCHED_FILER_RETRY", 2):
+            if str(item["srNum"]) == form_data["file_number"] or attempts >= max_attempts:
                 item["detailed_form_data"] = form_data
                 yield item
-                keep_trying = False
-            else:
-                attempts += 1
+                return  # done
 
-        if keep_trying:
+        attempts += 1
+        if attempts <= max_attempts:
             yield Request(
                 response.request.url,
                 cb_kwargs={"item": item, "report": report, "attempts": attempts},
                 callback=self.parse_html_report,
                 dont_filter=True,
             )
+        else:
+            print(f"Droppped item: {item}")
 
 
 class LM10Report:

--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -123,7 +123,7 @@ class LM20(Spider):
                 item["detailed_form_data"] = form_data
 
             elif attempts >= max_attempts:
-                print(
+                self.logger.warning(
                     f"could not parse report for srNum {item["srNum"]} at "
                     f"{response.request.url}"
                 )

--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -116,24 +116,26 @@ class LM20(Spider):
 
         max_attempts = self.settings.getint("MISMATCHED_FILER_RETRY", 2)
 
+        # Check for parsed report
         if content_type == "text/html" and b"Signature" in response.body:
             form_data = report.parse(response)
 
             if str(item["srNum"]) == form_data["file_number"]:
                 item["detailed_form_data"] = form_data
-
-            elif attempts >= max_attempts:
-                self.logger.warning(
-                    f"could not parse report for srNum {item["srNum"]} at "
-                    f"{response.request.url}"
-                )
-
+                yield item
+                return  # Happy path done
+        
+        # Check if we've exhausted attempts
+        if attempts == max_attempts:
+            self.logger.warning(
+                f"could not parse report for srNum {item["srNum"]} at "
+                f"{response.request.url}"
+            )
             yield item
-            return  # done
-
-        attempts += 1
-
-        if attempts <= max_attempts:
+        
+        else:
+            # Increment attempts and try again
+            attempts += 1
             yield Request(
                 response.request.url,
                 cb_kwargs={"item": item, "report": report, "attempts": attempts},

--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -132,6 +132,7 @@ class LM20(Spider):
                 f"{response.request.url}"
             )
             yield item
+            return  # Sad path done
         
         else:
             # Increment attempts and try again

--- a/lm10/spiders/filings.py
+++ b/lm10/spiders/filings.py
@@ -114,7 +114,7 @@ class LM20(Spider):
 
         content_type, _ = m.get_params()[0]
 
-        max_attempts = self.settings.getint("MISMATCHED_FILER_RETRY", 10)
+        max_attempts = self.settings.getint("MISMATCHED_FILER_RETRY", 2)
 
         if content_type == "text/html" and b"Signature" in response.body:
             form_data = report.parse(response)


### PR DESCRIPTION
The previous implementation only incremented attempts if an HTML response was returned. If we only ever got PDFs, then it would never be incremented, and we'd be stuck in an infinite loop of requests. This PR revises the routine to increment attempts with each unsuccessful request and bail appropriately.